### PR TITLE
Use dataset_pytest_iter pytest plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+.gantry/
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/test_dtparse.py
+++ b/test_dtparse.py
@@ -2,34 +2,39 @@ from .llms import make_model
 from .prompts import GOOD_PROMPT, BAD_PROMPT
 
 import gantry.dataset as gdataset
-from gantry.llm import EvaluationRun
+from gantry.dataset_pytest_plugin.plugin import dataset_pytest_iter
 
 # TODO: Change this to GOOD_PROMPT to make the test pass.
 PROMPT = BAD_PROMPT
 
 tag = "bug" if PROMPT == BAD_PROMPT else "fix"
 
+gdataset._init()
+dataset = gdataset.sync_dataset_data("evaluation_dataset.json")
+eval_metrics = ["exact_match"]
 
-def test_model():
+model = make_model(PROMPT)
+
+
+@dataset_pytest_iter(dataset, tag, eval_metrics)
+def test_model(input, label, join_key, run):
     """
     A simple test to make sure the model is working as expected. The 
     test works as follows:
-    
+
     1. Initialize the model with a prompt template.
     2. Load a dataset of test inputs from a json file. 
     3. Initialize a run with the dataset.
     4. Start the run. When we start the run, all OpenAI SDK calls
     will be tracked, and inputs & outputs will be logged locally.
     5. Iterate over the inputs and run the model on each input.
-    6. Assert that the run metrics are as expected.
+    6. Assert model predictions are as expected.
     """
-    model = make_model(PROMPT)
-    dataset = gdataset.sync_dataset_data(
-        "evaluation_dataset.json",
-    )
-    run = EvaluationRun(dataset)
-    with run.start(tag=tag):
-        for input in run.inputs:
-            model(**input)
+    model_output = model(**input)
 
-    assert run.metrics["exact_match"] == 1.0
+    # log run results
+    run.log_output(model_output, join_key)
+    run.log_metadata()
+
+    # assert that the model output is as expected
+    assert model_output.strip() == label


### PR DESCRIPTION
Use pytest plugin: dataset_pytest_iter 

Plugin is defined in Gantry Pre release SDK and can be used to iterate dataset records.

Here is a loom video about it: https://www.loom.com/share/0a6e376dc4264e0898159a103595e7e8

Plugin has been released in our latest SDK prerelase version: https://pypi.org/project/gantry/0.5.11b0/

Just install our prerelease sdk and everything else should just work out of the box:
```
pip install -U --pre gantry
pytest test_dtparse.py
```